### PR TITLE
Testing auto-assign PR workflow & iOS push notifications

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,8 +52,9 @@ Tradeoff:
 - Any external PR (including from forks) can trigger the assignment action.
   - Worst-case impact (under current design) is mostly notification/workflow spam and metadata churn.
 
+Note: Draft pull requests are already skipped until they are marked `ready_for_review` by the existing workflow triggers.
+
 Optional hardening knobs (if needed later):
-- Skip drafts until `ready_for_review`
 - Skip if already assigned
 - Add `concurrency` + short timeouts
 - Gate to trusted contributors using `author_association` (reduces drive-by spam but may block first-time contributors)


### PR DESCRIPTION
This pull request adds documentation to the `.github/workflows` directory, providing clear guidance on the purpose, configuration, and security model of the GitHub Actions workflows used for repo maintenance and PR triage. The new README explains how the `auto-assign-maintainer.yml` workflow operates, why assignment is used instead of other automation methods, and outlines safety constraints.

Documentation improvements:

* Added a comprehensive `.github/workflows/README.md` describing the `auto-assign-maintainer.yml` workflow, its triggers, purpose, configuration steps, mobile notification integration, security model, and testing/disabling instructions.
* Clarified the rationale for using assignment over CODEOWNERS or auto-request-review for PR triage, emphasizing explicit metadata and reliable notification triggers.
* Detailed security constraints, including minimal permissions, no code checkout, and fixed assignee, to ensure safe operation for PRs from forks.
* Provided optional hardening recommendations and clear instructions for testing and disabling the workflow.